### PR TITLE
Update version feign and fix communicator requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,11 @@
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
+
 group 'br.com.moip'
-version '1.1.5'
+version '1.1.6'
 archivesBaseName = "jassinaturas"
 sourceCompatibility = 1.7
 
@@ -14,11 +16,13 @@ repositories {
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.2.1'
     testCompile group: 'net.sourceforge.cobertura', name: 'cobertura', version: '2.0.3'
+    testCompile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
 
-    compile group: 'com.netflix.feign', name: 'feign-gson', version: '6.0.1'
-    compile group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+    compile group: 'io.github.openfeign', name: 'feign-okhttp', version: '9.3.1'
+    compile group: 'io.github.openfeign', name: 'feign-gson', version: '9.3.1'
+    compile group: 'io.github.openfeign', name: 'feign-slf4j', version: '9.3.1'
 }
 
 task javadocJar(type: Jar) {
@@ -84,6 +88,14 @@ uploadArchives {
                 }
 
             }
+        }
+    }
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
         }
     }
 }

--- a/src/main/java/br/com/moip/jassinaturas/communicators/CouponCommunicator.java
+++ b/src/main/java/br/com/moip/jassinaturas/communicators/CouponCommunicator.java
@@ -1,21 +1,21 @@
 package br.com.moip.jassinaturas.communicators;
 
 import br.com.moip.jassinaturas.clients.attributes.Coupon;
-import feign.RequestLine;
 
-import javax.inject.Named;
+import feign.Param;
+import feign.RequestLine;
 
 public interface CouponCommunicator {
 
     @RequestLine("GET /coupons/{code}")
-    Coupon show(@Named("code") String code);
+    Coupon show(@Param("code") String code);
 
     @RequestLine("POST /coupons")
     Coupon create(Coupon coupon);
 
     @RequestLine("PUT /coupons/{code}/active")
-    Coupon activate(@Named("code") String code);
+    Coupon activate(@Param("code") String code);
 
     @RequestLine("PUT /coupons/{code}/inactive")
-    Coupon inactivate(@Named("code") String code);
+    Coupon inactivate(@Param("code") String code);
 }

--- a/src/main/java/br/com/moip/jassinaturas/communicators/CustomerCommunicator.java
+++ b/src/main/java/br/com/moip/jassinaturas/communicators/CustomerCommunicator.java
@@ -2,9 +2,9 @@ package br.com.moip.jassinaturas.communicators;
 
 import br.com.moip.jassinaturas.clients.attributes.BillingInfo;
 import br.com.moip.jassinaturas.clients.attributes.Customer;
-import feign.RequestLine;
 
-import javax.inject.Named;
+import feign.Param;
+import feign.RequestLine;
 
 public interface CustomerCommunicator {
 
@@ -18,11 +18,11 @@ public interface CustomerCommunicator {
     Customer list();
 
     @RequestLine("GET /customers/{code}")
-    Customer show(@Named("code") String code);
+    Customer show(@Param("code") String code);
 
     @RequestLine("PUT /customers/{code}")
-    Customer update(@Named("code") String code, Customer customer);
+    Customer update(@Param("code") String code, Customer customer);
 
     @RequestLine("PUT /customers/{code}/billing_infos")
-    Customer updateCreditCard(@Named("code") String code, BillingInfo billingInfo);
+    Customer updateCreditCard(@Param("code") String code, BillingInfo billingInfo);
 }

--- a/src/main/java/br/com/moip/jassinaturas/communicators/InvoiceCommunicator.java
+++ b/src/main/java/br/com/moip/jassinaturas/communicators/InvoiceCommunicator.java
@@ -1,18 +1,18 @@
 package br.com.moip.jassinaturas.communicators;
 
 import br.com.moip.jassinaturas.clients.attributes.Invoice;
-import feign.RequestLine;
 
-import javax.inject.Named;
+import feign.Param;
+import feign.RequestLine;
 
 public interface InvoiceCommunicator {
 
     @RequestLine("GET /invoices/{id}/payments")
-    Invoice payments(@Named("id") int id);
+    Invoice payments(@Param("code") int id);
 
     @RequestLine("GET /invoices/{id}")
-    Invoice show(@Named("id") int id);
+    Invoice show(@Param("code") int id);
 
     @RequestLine("POST /invoices/{id}/retry")
-    Invoice retry(@Named("id") int id);
+    Invoice retry(@Param("code") int id);
 }

--- a/src/main/java/br/com/moip/jassinaturas/communicators/LocalCommunicator.java
+++ b/src/main/java/br/com/moip/jassinaturas/communicators/LocalCommunicator.java
@@ -1,13 +1,17 @@
 package br.com.moip.jassinaturas.communicators;
 
 import br.com.moip.jassinaturas.clients.attributes.Authentication;
-import br.com.moip.jassinaturas.feign.FixedHeadersInterceptor;
+
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import feign.Feign;
+import feign.Logger;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
+import feign.okhttp.OkHttpClient;
+import feign.slf4j.Slf4jLogger;
 
 public class LocalCommunicator implements Communicator {
 
@@ -16,12 +20,13 @@ public class LocalCommunicator implements Communicator {
                 .setDateFormat("dd/MM/yyyy")
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create();
-        return Feign
-                .builder()
-                .decoder(new GsonDecoder(gson))
-                .encoder(new GsonEncoder(gson))
-                .errorDecoder(new ErrorHandler())
-                .requestInterceptor(new FixedHeadersInterceptor())
-                .target(clazz, "http://localhost:9000");
+        return Feign.builder()
+            .client(new OkHttpClient())
+            .encoder(new GsonEncoder(gson))
+            .decoder(new GsonDecoder(gson))
+            .errorDecoder(new ErrorHandler())
+            .logger(new Slf4jLogger(clazz))
+            .logLevel( Logger.Level.FULL)
+            .target(clazz, "http://localhost:9000");
     }
 }

--- a/src/main/java/br/com/moip/jassinaturas/communicators/PlanCommunicator.java
+++ b/src/main/java/br/com/moip/jassinaturas/communicators/PlanCommunicator.java
@@ -1,27 +1,27 @@
 package br.com.moip.jassinaturas.communicators;
 
 import br.com.moip.jassinaturas.clients.attributes.Plan;
-import feign.RequestLine;
 
-import javax.inject.Named;
+import feign.Param;
+import feign.RequestLine;
 
 public interface PlanCommunicator {
 
     @RequestLine("PUT /plans/{code}/activate")
-    Plan activate(@Named("code") String code);
+    Plan activate(@Param("code") String code);
 
     @RequestLine("POST /plans")
     Plan create(Plan plan);
 
     @RequestLine("PUT /plans/{code}/inactivate")
-    Plan inactivate(@Named("code") String code);
+    Plan inactivate(@Param("code") String code);
 
     @RequestLine("GET /plans")
     Plan list();
 
     @RequestLine("GET /plans/{code}")
-    Plan show(@Named("code") String code);
+    Plan show(@Param("code") String code);
 
     @RequestLine("PUT /plans/{code}")
-    Plan update(@Named("code") String code, Plan plan);
+    Plan update(@Param("code") String code, Plan plan);
 }

--- a/src/main/java/br/com/moip/jassinaturas/communicators/ProductionCommunicator.java
+++ b/src/main/java/br/com/moip/jassinaturas/communicators/ProductionCommunicator.java
@@ -3,12 +3,17 @@ package br.com.moip.jassinaturas.communicators;
 import br.com.moip.jassinaturas.clients.attributes.Authentication;
 import br.com.moip.jassinaturas.feign.BasicAuthRequestInterceptor;
 import br.com.moip.jassinaturas.feign.FixedHeadersInterceptor;
+
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import feign.Feign;
+import feign.Logger;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
+import feign.okhttp.OkHttpClient;
+import feign.slf4j.Slf4jLogger;
 
 public class ProductionCommunicator implements Communicator {
 
@@ -17,15 +22,16 @@ public class ProductionCommunicator implements Communicator {
                 .setDateFormat("dd/MM/yyyy")
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create();
-        return Feign
-                .builder()
-                .decoder(new GsonDecoder(gson))
+        return Feign.builder()
+                .client(new OkHttpClient())
                 .encoder(new GsonEncoder(gson))
+                .decoder(new GsonDecoder(gson))
                 .errorDecoder(new ErrorHandler())
                 .requestInterceptor(
                         new BasicAuthRequestInterceptor(authentication.getToken(), authentication.getSecret()))
                 .requestInterceptor(new FixedHeadersInterceptor())
+                .logger(new Slf4jLogger(clazz))
+                .logLevel( Logger.Level.FULL)
                 .target(clazz, "https://api.moip.com.br/assinaturas/v1");
     }
-
 }

--- a/src/main/java/br/com/moip/jassinaturas/communicators/SandboxCommunicator.java
+++ b/src/main/java/br/com/moip/jassinaturas/communicators/SandboxCommunicator.java
@@ -3,12 +3,17 @@ package br.com.moip.jassinaturas.communicators;
 import br.com.moip.jassinaturas.clients.attributes.Authentication;
 import br.com.moip.jassinaturas.feign.BasicAuthRequestInterceptor;
 import br.com.moip.jassinaturas.feign.FixedHeadersInterceptor;
+
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import feign.Feign;
+import feign.Logger;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
+import feign.okhttp.OkHttpClient;
+import feign.slf4j.Slf4jLogger;
 
 public class SandboxCommunicator implements Communicator {
 
@@ -17,15 +22,16 @@ public class SandboxCommunicator implements Communicator {
                 .setDateFormat("dd/MM/yyyy")
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create();
-
-        return Feign
-                .builder()
-                .decoder(new GsonDecoder(gson))
-                .encoder(new GsonEncoder(gson))
-                .errorDecoder(new ErrorHandler())
-                .requestInterceptor(
-                        new BasicAuthRequestInterceptor(authentication.getToken(), authentication.getSecret()))
-                .requestInterceptor(new FixedHeadersInterceptor())
-                .target(clazz, "https://sandbox.moip.com.br/assinaturas/v1");
+        return Feign.builder()
+            .client(new OkHttpClient())
+            .encoder(new GsonEncoder(gson))
+            .decoder(new GsonDecoder(gson))
+            .errorDecoder(new ErrorHandler())
+            .requestInterceptor(
+                    new BasicAuthRequestInterceptor(authentication.getToken(), authentication.getSecret()))
+            .requestInterceptor(new FixedHeadersInterceptor())
+            .logger(new Slf4jLogger(clazz))
+            .logLevel( Logger.Level.FULL)
+            .target(clazz, "https://sandbox.moip.com.br/assinaturas/v1");
     }
 }

--- a/src/main/java/br/com/moip/jassinaturas/communicators/SubscriptionCommunicator.java
+++ b/src/main/java/br/com/moip/jassinaturas/communicators/SubscriptionCommunicator.java
@@ -1,17 +1,17 @@
 package br.com.moip.jassinaturas.communicators;
 
 import br.com.moip.jassinaturas.clients.attributes.Subscription;
-import feign.RequestLine;
 
-import javax.inject.Named;
+import feign.Param;
+import feign.RequestLine;
 
 public interface SubscriptionCommunicator {
 
     @RequestLine("PUT /subscriptions/{code}/activate")
-    Subscription activate(@Named("code") String code);
+    Subscription activate(@Param("code") String code);
 
     @RequestLine("PUT /subscriptions/{code}/cancel")
-    Subscription cancel(@Named("code") String code);
+    Subscription cancel(@Param("code") String code);
 
     @RequestLine("POST /subscriptions?new_customer=true")
     Subscription createWithCustomer(Subscription subscription);
@@ -20,18 +20,18 @@ public interface SubscriptionCommunicator {
     Subscription createWithoutCustomer(Subscription subscription);
 
     @RequestLine("GET /subscriptions/{code}/invoices")
-    Subscription invoices(@Named("code") String subscriptionCode);
+    Subscription invoices(@Param("code") String subscriptionCode);
 
     @RequestLine("GET /subscriptions")
     Subscription list();
 
     @RequestLine("GET /subscriptions/{code}")
-    Subscription show(@Named("code") String code);
+    Subscription show(@Param("code") String code);
 
     @RequestLine("PUT /subscriptions/{code}/suspend")
-    Subscription suspend(@Named("code") String code);
+    Subscription suspend(@Param("code") String code);
 
     @RequestLine("PUT /subscriptions/{code}")
-    Subscription update(@Named("code") String code, Subscription subscription);
+    Subscription update(@Param("code") String code, Subscription subscription);
 
 }


### PR DESCRIPTION
- [x] Versão do Feign atualizada para a mais recente disponibilizada pelo github.
- [x] Configurando para logar como `DEBUG` as requests realizadas.
- [x] Configurando clients com a anotação `@Param` para parâmetros na URL das requests.
- [x] Refatorando builders do Feign para logar com `Slf4j` e utilizar o `OkHttpClient` do Feign.
  