### PR TITLE
Excludes the client that was using Feign-OkHttp Module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,12 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'net.sourceforge.cobertura', name: 'cobertura', version: '2.0.3'
     testCompile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
-
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-    compile group: 'io.github.openfeign', name: 'feign-okhttp', version: '9.3.1'
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '1.4.3.RELEASE'
     compile group: 'io.github.openfeign', name: 'feign-gson', version: '9.3.1'
     compile group: 'io.github.openfeign', name: 'feign-slf4j', version: '9.3.1'
+    
+    
 }
 
 task javadocJar(type: Jar) {

--- a/src/main/java/br/com/moip/jassinaturas/communicators/LocalCommunicator.java
+++ b/src/main/java/br/com/moip/jassinaturas/communicators/LocalCommunicator.java
@@ -10,7 +10,6 @@ import feign.Feign;
 import feign.Logger;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
-import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
 
 public class LocalCommunicator implements Communicator {
@@ -21,7 +20,6 @@ public class LocalCommunicator implements Communicator {
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create();
         return Feign.builder()
-            .client(new OkHttpClient())
             .encoder(new GsonEncoder(gson))
             .decoder(new GsonDecoder(gson))
             .errorDecoder(new ErrorHandler())

--- a/src/main/java/br/com/moip/jassinaturas/communicators/ProductionCommunicator.java
+++ b/src/main/java/br/com/moip/jassinaturas/communicators/ProductionCommunicator.java
@@ -1,18 +1,16 @@
 package br.com.moip.jassinaturas.communicators;
 
-import br.com.moip.jassinaturas.clients.attributes.Authentication;
-import br.com.moip.jassinaturas.feign.BasicAuthRequestInterceptor;
-import br.com.moip.jassinaturas.feign.FixedHeadersInterceptor;
-
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import br.com.moip.jassinaturas.clients.attributes.Authentication;
+import br.com.moip.jassinaturas.feign.BasicAuthRequestInterceptor;
+import br.com.moip.jassinaturas.feign.FixedHeadersInterceptor;
 import feign.Feign;
 import feign.Logger;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
-import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
 
 public class ProductionCommunicator implements Communicator {
@@ -23,7 +21,6 @@ public class ProductionCommunicator implements Communicator {
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create();
         return Feign.builder()
-                .client(new OkHttpClient())
                 .encoder(new GsonEncoder(gson))
                 .decoder(new GsonDecoder(gson))
                 .errorDecoder(new ErrorHandler())

--- a/src/main/java/br/com/moip/jassinaturas/communicators/SandboxCommunicator.java
+++ b/src/main/java/br/com/moip/jassinaturas/communicators/SandboxCommunicator.java
@@ -1,18 +1,16 @@
 package br.com.moip.jassinaturas.communicators;
 
-import br.com.moip.jassinaturas.clients.attributes.Authentication;
-import br.com.moip.jassinaturas.feign.BasicAuthRequestInterceptor;
-import br.com.moip.jassinaturas.feign.FixedHeadersInterceptor;
-
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import br.com.moip.jassinaturas.clients.attributes.Authentication;
+import br.com.moip.jassinaturas.feign.BasicAuthRequestInterceptor;
+import br.com.moip.jassinaturas.feign.FixedHeadersInterceptor;
 import feign.Feign;
 import feign.Logger;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
-import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
 
 public class SandboxCommunicator implements Communicator {
@@ -23,7 +21,6 @@ public class SandboxCommunicator implements Communicator {
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create();
         return Feign.builder()
-            .client(new OkHttpClient())
             .encoder(new GsonEncoder(gson))
             .decoder(new GsonDecoder(gson))
             .errorDecoder(new ErrorHandler())


### PR DESCRIPTION
The project was using the Feign-OkHttp module as the Client, but the OpenFeign (currently used in spring projects) uses the OkHttp3 as default Client. The new way to build a Feign isn't passing the Client.